### PR TITLE
docs: expand README, add AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md — watermeter
+
+Guidance for AI coding agents working in this repo. Humans: see [README.md](README.md).
+
+## What this is
+
+A Raspberry Pi water-meter monitor with automatic + remote water shutoff. A
+meter pulse = 0.1 gallon. The rpi service counts pulses, records them, closes a
+valve on runaway flow, and accepts remote open/close commands via SMS → Lambda →
+SQS. Read the README for the full architecture before making changes.
+
+## Module structure — this is a multi-module monorepo
+
+There are **three separate Go modules**; there is no single root `go.mod`. Run
+Go commands from inside the relevant module directory:
+
+| Directory            | Module                                | Go   |
+|----------------------|---------------------------------------|------|
+| `rpi/`               | `github.com/anthonywittig/watermeter` | 1.14 |
+| `lambdas/`           | `lambdas`                             | 1.19 |
+| `bin/deploy-lambda/` | `deploy-lambda`                       | 1.18 |
+
+So `cd rpi && go build ./...`, `cd lambdas && go test ./...`, etc. A command run
+at the repo root will not see any module.
+
+## Build / test / run
+
+- `make build` — builds `rpi/` to `bin/watermeter`; copies the `.env` from the
+  sibling `watermeter-config` repo. **Requires `../watermeter-config` to exist.**
+- `make run` — build, stop the systemd service, run the binary in the foreground.
+- `make deploy-lambdas token=<MFA>` — vet/test/build/zip and deploy the lambda.
+- Lambda CI-ish checks live in `bin/deploy-lambda/run.sh`: `go generate`,
+  `go vet`, `go test` over `lambdas/`, then cross-compile `GOOS=linux GOARCH=amd64`.
+
+There is no test suite of substance yet; prefer adding tests next to the code in
+the module you touch.
+
+## Conventions and constraints
+
+- **Hardware is real.** `rpi/watermeter/hardware.go` and `iot/valve.go` use
+  `go-rpio` and BCM pin numbers (meter=18, LED=17, valve open=19, close=26).
+  This code only runs on the Pi; it can't be exercised on a laptop. Be careful
+  changing pin assignments or relay polarity — the valve relays are **active-low**
+  and held for 10 s per actuation.
+- **Units:** one pulse = 0.1 gallon. Keep that constant consistent across
+  `prometheus.go`, `gcpmonitor.go`, and `flowmonitor.go`.
+- **Pulse listeners** implement the `PulseHandler` interface and are fanned out
+  in `pulselisteners/pulselistener.go`. Add new sinks by implementing the
+  interface and appending to the handler slice; handlers must not block.
+- **Concurrency:** components are started with a shared `context.Context` and a
+  `sync.WaitGroup`; respect cancellation (`<-ctx.Done()`) and call `wg.Done()`.
+- **AWS:** the rpi side uses the shared-config profile `water-meter-rpi`; the
+  SQS queue is `water-meter-rpi.fifo`. The SQS message type is `ValveChangeRequested{ Level int }`.
+
+## Secrets — do NOT commit them here
+
+Real config and secrets live in the sibling `watermeter-config` repo, not this
+one. `.gitignore` excludes `*.env`, `*.gcp.credentials.json`, `bin/`, and
+`.env.json`. Never add real Twilio/AWS/GCP credentials to this repo; update the
+`.env.example*` files to document new config keys instead.
+
+## When you change config shape
+
+If you add or rename an environment variable, update **both**:
+- the `*.env.example*` file in this repo, and
+- the corresponding real file in `watermeter-config` (the user maintains that),
+  and mention it so they can update the deployed config.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+See [AGENTS.md](AGENTS.md) for agent-facing guidance on this repo (module
+layout, build/test commands, hardware constraints, and secret handling). It is
+the single source of truth; this file just points to it so the two don't drift.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 A Raspberry Pi–based water meter monitor with automatic and remote water shutoff.
 
-A reed/button-style sensor on the house water meter generates one pulse per
-0.1 gallon. A Go service on the Pi counts those pulses, records them to several
-backends, and watches for runaway flow. If too much water flows in a short
+The house water meter has a magnet on its spinning dial; a passive two-wire reed
+switch mounted next to the dial closes once per revolution, generating one pulse
+per 0.1 gallon. A Go service on the Pi counts those pulses, records them to
+several backends, and watches for runaway flow. If too much water flows in a short
 window (e.g. a burst pipe), it automatically closes a motorized valve and texts
 you. You can also open/close the valve remotely by sending a text message.
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,123 @@
 # watermeter
 
-Original wiring for meter pluse comes from https://github.com/Freenove/Freenove_Ultimate_Starter_Kit_for_Raspberry_Pi/blob/master/Tutorial.pdf, chapter 2 (the button wiring).
+A Raspberry Pi–based water meter monitor with automatic and remote water shutoff.
 
+A reed/button-style sensor on the house water meter generates one pulse per
+0.1 gallon. A Go service on the Pi counts those pulses, records them to several
+backends, and watches for runaway flow. If too much water flows in a short
+window (e.g. a burst pipe), it automatically closes a motorized valve and texts
+you. You can also open/close the valve remotely by sending a text message.
 
-## DB creation (poor man's migrations)
+```
+                          ┌──────────────────────────────────────────┐
+  water meter ──pulse──▶  │ rpi service (Go, runs on the Raspberry Pi)│
+  (GPIO 18)               │                                           │
+                          │  pulse fan-out ─▶ Postgres                │
+                          │                ─▶ Prometheus (:8000)      │
+                          │                ─▶ GCP custom metric       │
+                          │                                           │
+                          │  flow monitor ─▶ close valve + Twilio SMS │
+                          │                  (> 20 gal / 5 min)       │
+                          │                                           │
+   text "0".."10" ──▶ Twilio ─▶ inbound-text Lambda ─▶ SQS ─▶ remote  │
+                          │     (Function URL)        (FIFO) control ─▶ valve
+                          └──────────────────────────────────────────┘
+```
 
+Original meter pulse wiring comes from the
+[Freenove Ultimate Starter Kit tutorial](https://github.com/Freenove/Freenove_Ultimate_Starter_Kit_for_Raspberry_Pi/blob/master/Tutorial.pdf),
+chapter 2 (the button wiring).
+
+## Repository layout
+
+This is a monorepo containing **three independent Go modules**:
+
+| Path                 | Module                                | Go   | What it is |
+|----------------------|---------------------------------------|------|------------|
+| `rpi/`               | `github.com/anthonywittig/watermeter` | 1.14 | The long-running service that runs on the Raspberry Pi. |
+| `lambdas/`           | `lambdas`                             | 1.19 | AWS Lambda(s). Currently `inbound-text`, the Twilio inbound-SMS webhook. |
+| `bin/deploy-lambda/` | `deploy-lambda`                       | 1.18 | A Go tool that builds and deploys a lambda (function, IAM role, SQS queue). |
+
+Other directories:
+
+- `dev/` — `build.sh`, and the `watermeter.service` systemd unit (runs as user `pi`).
+- `rpi/monitoring/` — Prometheus + postgres_exporter Docker setup for the Pi.
+
+## How the rpi service works
+
+`rpi/main.go` wires everything together and blocks until interrupted. The pieces:
+
+- **Hardware** (`watermeter/hardware.go`) — uses BCM GPIO pins: meter input on
+  18 (pulled up), status LED on 17, valve relays on 19 (open) / 26 (close).
+  Polls the meter every 200 ms and emits a `time.Time` on the `pulse` channel
+  on each falling edge.
+- **Pulse listeners** (`watermeter/pulselisteners/`) — every pulse is fanned out
+  to all handlers; one slow/failing handler doesn't block the others:
+  - `database.go` — inserts a row into the Postgres `meter` table.
+  - `prometheus.go` — increments a `gallons` counter (0.1 per pulse).
+  - `gcpmonitor.go` — writes a GCP custom metric, batched (~every 30 s, since
+    GCP caps reporting at one point per 10 s).
+- **Flow monitor** (`watermeter/flowmonitor.go`) — every 5 minutes, counts
+  pulses in the last 5 minutes. If > 20 gallons, it **closes the valve** and
+  sends a Twilio SMS alert.
+- **Remote control** (`watermeter/remotecontrol.go`) — polls the SQS FIFO queue
+  `water-meter-rpi.fifo` every 10 s (AWS profile `water-meter-rpi`). A message
+  with `level <= 0` closes the valve; anything else opens it.
+- **Valve** (`watermeter/iot/valve.go`) — drives a two-relay motorized valve;
+  relays are active-low and held for 10 s per actuation (mutex-guarded).
+- **Texter** (`watermeter/texter.go`) — Twilio SMS client.
+- Prometheus metrics are served at `:8000/metrics`.
+
+## How the inbound text flow works
+
+1. You text a number `0`–`10` to the Twilio number.
+2. Twilio calls the `inbound-text` Lambda's Function URL.
+3. The Lambda validates the Twilio signature, checks the sender against an
+   allow-list, and pushes the number as a valve "level" onto the SQS FIFO queue.
+4. The rpi remote-control loop picks it up and opens/closes the valve.
+5. The Lambda texts back a confirmation.
+
+## Configuration
+
+Secrets and environment config are **not** stored in this repo — they live in
+the sibling [`watermeter-config`](https://github.com/anthonywittig/watermeter-config)
+repo, which must be cloned next to this one (`../watermeter-config`).
+
+- `dev/build.sh` copies `../watermeter-config/config/rpi/.env` into `bin/`.
+- The lambda's `.env.json` is supplied by `watermeter-config`'s deploy step.
+
+See `rpi/.env.example` and `lambdas/cmd/inbound-text/.env.example.json` for the
+shape of the config.
+
+## Database (poor man's migrations)
+
+```sql
 create table meter (
    id serial primary key,
    recorded_at timestamp not null
 );
+```
 
-## Twilio
+## Building and running
 
-You'll need to set up the webhook configuration.
+From the repo root (`make` targets):
 
-## Lambda
+```sh
+make build           # builds rpi/ -> bin/watermeter and copies the .env
+make run             # build, stop the service, run bin/watermeter in foreground
+make startService    # sudo systemctl restart watermeter
+make stopService     # sudo systemctl stop watermeter
+make deploy-lambdas token=<MFA>   # build + deploy the inbound-text lambda
+```
 
-You'll need to enable the `Function URL` (update the deploy code to do so).
+Deploying a lambda runs `bin/deploy-lambda/run.sh <profile> <name> <mfa-token>`,
+which vets/tests, cross-compiles for `linux/amd64`, zips, and creates/updates
+the function, IAM role, and SQS queue.
+
+## Setup notes / gotchas
+
+- **Twilio** — you must configure the webhook to point at the Lambda Function URL.
+- **Lambda** — the `Function URL` must be enabled (the deploy tool doesn't do
+  this yet — see `bin/deploy-lambda/main.go`).
+- The two config repos must be cloned side by side for the build to find the
+  `.env` files.


### PR DESCRIPTION
Rewrites the README from scattered notes into a full overview and adds agent-facing docs.

## README.md
- Architecture diagram + the three-module monorepo layout
- How the rpi service works (GPIO hardware, pulse fan-out to Postgres/Prometheus/GCP, flow monitor + auto valve shutoff, SQS remote control)
- The Twilio inbound-text → Lambda → SQS flow
- Configuration via the sibling `watermeter-config` repo, DB schema, and `make` targets/gotchas

## AGENTS.md (new)
- Multi-module gotcha (run Go commands inside each module), build/test/deploy commands
- Hardware constraints (real GPIO, active-low relays, pulse = 0.1 gal), the `PulseHandler` fan-out pattern, AWS profile/queue names
- "Secrets live in watermeter-config, not here"

## CLAUDE.md (new)
- One-line pointer to AGENTS.md to avoid drift

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)