### PR TITLE
docs: document the rpi deploy process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ stopService:
 
 deploy-lambdas:
 	./bin/deploy-lambda/run.sh watermeter-deployer-role inbound-text $(token)
+
+deploy-rpi:
+	./dev/deploy-rpi.sh $(pi)

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ create table meter (
 
 ## Building and running
 
-**Deploying to the Pi:** the Pi can't build or pull this repo itself (old Go,
-no GitHub auth) — cross-compile on your workstation and copy the binary over.
-See **[docs/rpi-deploy.md](docs/rpi-deploy.md)** for the full recipe, including
+**Deploying to the Pi:** the Pi's Go is too old to build this repo — cross-compile
+on your workstation and copy the binary over. See
+**[docs/rpi-deploy.md](docs/rpi-deploy.md)** for the full recipe, including
 verification and rollback.
 
 On a machine with Go ≥ 1.23, the `make` targets still work from the repo root:

--- a/README.md
+++ b/README.md
@@ -147,10 +147,15 @@ create table meter (
 
 ## Building and running
 
-From the repo root (`make` targets):
+**Deploying to the Pi:** the Pi can't build or pull this repo itself (old Go,
+no GitHub auth) — cross-compile on your workstation and copy the binary over.
+See **[docs/rpi-deploy.md](docs/rpi-deploy.md)** for the full recipe, including
+verification and rollback.
+
+On a machine with Go ≥ 1.23, the `make` targets still work from the repo root:
 
 ```sh
-make build           # builds rpi/ -> bin/watermeter and copies the .env
+make build           # builds rpi/ -> bin/watermeter, copies .env + service-account
 make run             # build, stop the service, run bin/watermeter in foreground
 make startService    # sudo systemctl restart watermeter
 make stopService     # sudo systemctl stop watermeter

--- a/dev/deploy-rpi.sh
+++ b/dev/deploy-rpi.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Deploy the rpi service to the Raspberry Pi.
+#
+#   ./dev/deploy-rpi.sh <pi-address>
+#
+# Cross-compiles for the Pi (armv7l), backs up the running binary, copies the
+# binary + config from the sibling watermeter-config repo, and restarts the
+# systemd service. See docs/rpi-deploy.md for details and rollback.
+
+set -e
+
+# start in the repo root (this script lives in dev/)
+cd "$(dirname "$0")/.."
+
+PI_ADDRESS="$1"
+if [[ -z "$PI_ADDRESS" ]]; then
+    echo "Usage: $0 <pi-address>" >&2
+    exit 1
+fi
+PI="pi@${PI_ADDRESS}"
+PI_BIN="projects/watermeter/bin"
+
+CONFIG_DIR="../watermeter-config/config"
+for f in "$CONFIG_DIR/rpi/.env" "$CONFIG_DIR/firebase/service-account.json"; do
+    if [[ ! -f "$f" ]]; then
+        echo "Missing $f -- is watermeter-config cloned next to this repo?" >&2
+        exit 1
+    fi
+done
+
+echo "==> Cross-compiling for the Pi (linux/arm, armv7)"
+BUILD_OUT=$(mktemp -d)
+trap 'rm -rf "$BUILD_OUT"' EXIT
+(cd rpi && GOOS=linux GOARCH=arm GOARM=7 go build -o "$BUILD_OUT/watermeter" main.go)
+
+echo "==> Stopping the service and backing up the current binary"
+ssh "$PI" "sudo systemctl stop watermeter && { [ -f ~/$PI_BIN/watermeter ] && cp ~/$PI_BIN/watermeter ~/$PI_BIN/watermeter.bak || true; }"
+
+echo "==> Copying binary + config"
+scp -q "$BUILD_OUT/watermeter"                        "$PI:$PI_BIN/watermeter"
+scp -q "$CONFIG_DIR/rpi/.env"                         "$PI:$PI_BIN/.env"
+scp -q "$CONFIG_DIR/firebase/service-account.json"    "$PI:$PI_BIN/service-account.json"
+
+echo "==> Restarting the service"
+ssh "$PI" "chmod +x ~/$PI_BIN/watermeter && sudo systemctl start watermeter"
+
+echo "==> Waiting for startup (valve init takes ~20s)"
+sleep 25
+
+echo "==> Verifying"
+STATUS=$(ssh "$PI" "systemctl is-active watermeter" || true)
+echo "service status: $STATUS"
+if [[ "$STATUS" != "active" ]]; then
+    echo "Service is not active! Recent logs:" >&2
+    ssh "$PI" "sudo journalctl -u watermeter -n 30 --no-pager" >&2
+    echo "Rollback: see docs/rpi-deploy.md (bin/watermeter.bak)" >&2
+    exit 1
+fi
+
+if ssh "$PI" "sudo journalctl -u watermeter --since '1 minute ago' --no-pager" | grep -iE "fatal|panic"; then
+    echo "Service is active but logged fatal/panic above — investigate." >&2
+    exit 1
+fi
+
+echo "==> Deploy complete. Recent logs:"
+ssh "$PI" "sudo journalctl -u watermeter -n 12 --no-pager"

--- a/docs/rpi-deploy.md
+++ b/docs/rpi-deploy.md
@@ -5,13 +5,9 @@ on your workstation, `scp` into the Pi's `bin/`, restart the systemd service.**
 
 ## Why not build on the Pi?
 
-The original flow (`make build` on the Pi) no longer works, and the Pi also
-can't pull from GitHub:
-
-- **Go version.** `rpi/go.mod` requires Go ≥ 1.23 (for the Firestore SDK); the
-  Pi has Go 1.14 and is slow to build on anyway.
-- **Git auth.** The Pi has no GitHub credentials, so `git pull` fails there.
-  Deploying by copying files sidesteps both problems.
+The original flow (`make build` on the Pi) no longer works: `rpi/go.mod`
+requires Go ≥ 1.23 (for the Firestore SDK), the Pi's Go is older, and it's slow
+to build on anyway. Deploying by copying files sidesteps that.
 
 The Pi is an **armv7l (32-bit)** Raspberry Pi, so cross-compile with
 `GOOS=linux GOARCH=arm GOARM=7`. Go produces a statically-linked binary — no
@@ -22,15 +18,7 @@ runtime deps needed on the Pi.
 - Both repos cloned side by side on your workstation (`watermeter` +
   `watermeter-config`), with `watermeter-config` populated (rpi `.env`,
   `config/firebase/service-account.json`).
-- **SSH key auth to the Pi** so the copy steps don't prompt for a password:
-
-  ```sh
-  ssh-copy-id pi@<pi-address>    # enter the Pi password once
-  ssh pi@<pi-address> echo ok    # verify: no password prompt
-  ```
-
-  This installs your workstation's public key into the Pi's
-  `~/.ssh/authorized_keys`. Password login keeps working; key auth is additive.
+- SSH access to the Pi as the `pi` user.
 - The `pi` user can `sudo systemctl` without a password (default on Raspbian).
 
 ## Deploy steps

--- a/docs/rpi-deploy.md
+++ b/docs/rpi-deploy.md
@@ -21,15 +21,26 @@ runtime deps needed on the Pi.
 - SSH access to the Pi as the `pi` user.
 - The `pi` user can `sudo systemctl` without a password (default on Raspbian).
 
-## Deploy steps
+## Deploy
 
 From the `watermeter` repo root on your workstation (replace `<pi-address>`
 with your Pi's hostname or IP):
 
 ```sh
-# 0. Be on the code you mean to ship
-git checkout master && git pull
+git checkout master && git pull       # be on the code you mean to ship
+./dev/deploy-rpi.sh <pi-address>      # or: make deploy-rpi pi=<pi-address>
+```
 
+The script cross-compiles, stops the service, backs up the running binary to
+`bin/watermeter.bak`, copies the binary + `.env` + `service-account.json` into
+the Pi's `bin/`, restarts, and verifies the service came up without
+fatals/panics (it fails loudly and prints logs if not).
+
+### What it does, step by step
+
+Equivalent manual steps, if you ever need them:
+
+```sh
 # 1. Cross-compile for the Pi (armv7l, 32-bit)
 (cd rpi && GOOS=linux GOARCH=arm GOARM=7 go build -o /tmp/watermeter main.go)
 
@@ -49,7 +60,10 @@ ssh pi@<pi-address> \
 
 Config-only changes (a `.env` edit, a new service-account key) are steps 2–4
 without the compile: the service reads config at startup, so copy the file and
-restart.
+restart. (Or just run the full script — the rebuild is cheap.)
+
+Note: every deploy restarts the service, and startup cycles the valve
+(close → open, ~20 s) — a brief water interruption.
 
 ## Verify
 

--- a/docs/rpi-deploy.md
+++ b/docs/rpi-deploy.md
@@ -23,8 +23,8 @@ runtime deps needed on the Pi.
 
 ## Deploy steps
 
-From the `watermeter` repo root on your workstation (Pi address used below:
-`192.168.86.135`):
+From the `watermeter` repo root on your workstation (replace `<pi-address>`
+with your Pi's hostname or IP):
 
 ```sh
 # 0. Be on the code you mean to ship
@@ -34,16 +34,16 @@ git checkout master && git pull
 (cd rpi && GOOS=linux GOARCH=arm GOARM=7 go build -o /tmp/watermeter main.go)
 
 # 2. Stop the service and back up the running binary (rollback point)
-ssh pi@192.168.86.135 \
+ssh pi@<pi-address> \
   'sudo systemctl stop watermeter && cp ~/projects/watermeter/bin/watermeter ~/projects/watermeter/bin/watermeter.bak'
 
 # 3. Copy the binary + config into the Pi's bin/
-scp /tmp/watermeter                                            pi@192.168.86.135:projects/watermeter/bin/watermeter
-scp ../watermeter-config/config/rpi/.env                       pi@192.168.86.135:projects/watermeter/bin/.env
-scp ../watermeter-config/config/firebase/service-account.json  pi@192.168.86.135:projects/watermeter/bin/service-account.json
+scp /tmp/watermeter                                            pi@<pi-address>:projects/watermeter/bin/watermeter
+scp ../watermeter-config/config/rpi/.env                       pi@<pi-address>:projects/watermeter/bin/.env
+scp ../watermeter-config/config/firebase/service-account.json  pi@<pi-address>:projects/watermeter/bin/service-account.json
 
 # 4. Restart and verify
-ssh pi@192.168.86.135 \
+ssh pi@<pi-address> \
   'chmod +x ~/projects/watermeter/bin/watermeter && sudo systemctl start watermeter && sleep 25 && systemctl is-active watermeter'
 ```
 
@@ -54,7 +54,7 @@ restart.
 ## Verify
 
 ```sh
-ssh pi@192.168.86.135 'sudo journalctl -u watermeter -n 50 --no-pager'
+ssh pi@<pi-address> 'sudo journalctl -u watermeter -n 50 --no-pager'
 ```
 
 Healthy startup looks like:
@@ -72,7 +72,7 @@ PWA should print `firestore control: opening valve` / `closing valve`.
 ## Rollback
 
 ```sh
-ssh pi@192.168.86.135 \
+ssh pi@<pi-address> \
   'sudo systemctl stop watermeter && cp ~/projects/watermeter/bin/watermeter.bak ~/projects/watermeter/bin/watermeter && sudo systemctl start watermeter'
 ```
 

--- a/docs/rpi-deploy.md
+++ b/docs/rpi-deploy.md
@@ -1,0 +1,104 @@
+# Deploying to the Raspberry Pi
+
+How the rpi service gets built and shipped. The short version: **cross-compile
+on your workstation, `scp` into the Pi's `bin/`, restart the systemd service.**
+
+## Why not build on the Pi?
+
+The original flow (`make build` on the Pi) no longer works, and the Pi also
+can't pull from GitHub:
+
+- **Go version.** `rpi/go.mod` requires Go ≥ 1.23 (for the Firestore SDK); the
+  Pi has Go 1.14 and is slow to build on anyway.
+- **Git auth.** The Pi has no GitHub credentials, so `git pull` fails there.
+  Deploying by copying files sidesteps both problems.
+
+The Pi is an **armv7l (32-bit)** Raspberry Pi, so cross-compile with
+`GOOS=linux GOARCH=arm GOARM=7`. Go produces a statically-linked binary — no
+runtime deps needed on the Pi.
+
+## Prerequisites (one-time)
+
+- Both repos cloned side by side on your workstation (`watermeter` +
+  `watermeter-config`), with `watermeter-config` populated (rpi `.env`,
+  `config/firebase/service-account.json`).
+- **SSH key auth to the Pi** so the copy steps don't prompt for a password:
+
+  ```sh
+  ssh-copy-id pi@<pi-address>    # enter the Pi password once
+  ssh pi@<pi-address> echo ok    # verify: no password prompt
+  ```
+
+  This installs your workstation's public key into the Pi's
+  `~/.ssh/authorized_keys`. Password login keeps working; key auth is additive.
+- The `pi` user can `sudo systemctl` without a password (default on Raspbian).
+
+## Deploy steps
+
+From the `watermeter` repo root on your workstation (Pi address used below:
+`192.168.86.135`):
+
+```sh
+# 0. Be on the code you mean to ship
+git checkout master && git pull
+
+# 1. Cross-compile for the Pi (armv7l, 32-bit)
+(cd rpi && GOOS=linux GOARCH=arm GOARM=7 go build -o /tmp/watermeter main.go)
+
+# 2. Stop the service and back up the running binary (rollback point)
+ssh pi@192.168.86.135 \
+  'sudo systemctl stop watermeter && cp ~/projects/watermeter/bin/watermeter ~/projects/watermeter/bin/watermeter.bak'
+
+# 3. Copy the binary + config into the Pi's bin/
+scp /tmp/watermeter                                            pi@192.168.86.135:projects/watermeter/bin/watermeter
+scp ../watermeter-config/config/rpi/.env                       pi@192.168.86.135:projects/watermeter/bin/.env
+scp ../watermeter-config/config/firebase/service-account.json  pi@192.168.86.135:projects/watermeter/bin/service-account.json
+
+# 4. Restart and verify
+ssh pi@192.168.86.135 \
+  'chmod +x ~/projects/watermeter/bin/watermeter && sudo systemctl start watermeter && sleep 25 && systemctl is-active watermeter'
+```
+
+Config-only changes (a `.env` edit, a new service-account key) are steps 2–4
+without the compile: the service reads config at startup, so copy the file and
+restart.
+
+## Verify
+
+```sh
+ssh pi@192.168.86.135 'sudo journalctl -u watermeter -n 50 --no-pager'
+```
+
+Healthy startup looks like:
+
+- `starting up`, then the valve init sequence (`setting up valve` … `after
+  initial valve settings` — this takes ~20 s; the valve relays cycle on boot),
+- `remote control tick` every ~10 s (the SQS poller),
+- `wm pulse @ …` lines whenever water is flowing,
+- **no** `Fatal`/`panic` lines. A fatal during the first seconds usually means a
+  config problem (bad `.env`, missing/invalid `service-account.json`, no DB).
+
+The Firestore valve listener is silent until it acts: toggling the valve in the
+PWA should print `firestore control: opening valve` / `closing valve`.
+
+## Rollback
+
+```sh
+ssh pi@192.168.86.135 \
+  'sudo systemctl stop watermeter && cp ~/projects/watermeter/bin/watermeter.bak ~/projects/watermeter/bin/watermeter && sudo systemctl start watermeter'
+```
+
+(If the bad deploy included config changes, restore the matching `.env` /
+service-account file too — config lives in `watermeter-config` git history.)
+
+## Notes
+
+- `dev/build.sh` / `make build` still work **on a machine with Go ≥ 1.23** and
+  a sibling `watermeter-config` checkout; they build into `bin/` and copy the
+  config. The cross-compile flow above is the supported path to the actual Pi.
+- The systemd unit is `dev/watermeter.service`
+  (`ExecStart=/home/pi/projects/watermeter/bin/watermeter`, runs as `pi`,
+  auto-restarts). If it changes: copy it to
+  `/etc/systemd/system/watermeter.service` and `sudo systemctl daemon-reload`.
+- The service loads `.env` from the directory next to the binary, so keeping
+  binary + `.env` + `service-account.json` together in `bin/` is required.


### PR DESCRIPTION
Documents how the rpi service actually gets deployed now that the Pi can't build the code itself (its Go predates the ≥ 1.23 requirement that landed with the Firestore SDK).

**[docs/rpi-deploy.md](https://github.com/anthonywittig/watermeter/blob/docs/rpi-deploy/docs/rpi-deploy.md)** covers:
- One-time prerequisites (SSH access to the Pi, sibling `watermeter-config` checkout)
- The deploy recipe: cross-compile `GOOS=linux GOARCH=arm GOARM=7` (the Pi is 32-bit armv7l) → stop service + back up binary → `scp` binary/`.env`/`service-account.json` into `bin/` → restart
- Config-only deploys, what healthy startup logs look like, and rollback via `bin/watermeter.bak`

README's Building section now points here. This is the exact process used for the Phase 2b deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)